### PR TITLE
Made some updates to your script...

### DIFF
--- a/get-all-certs.ps1
+++ b/get-all-certs.ps1
@@ -1,6 +1,7 @@
 #
 
 $StoreToDir = "all-certificates"
+$CertExtension = "pem" # use "crt" for usage on windows systems
 $InsertLineBreaks=1
 
 If (Test-Path $StoreToDir) {
@@ -9,33 +10,33 @@ If (Test-Path $StoreToDir) {
 }
 New-Item $StoreToDir -ItemType directory
 
+# If you want to filter by Cert Usage (ex. for language independent match proividing server authentificaten Certs: "(1.3.6.1.5.5.7.3.1)"), just add:
+# -and -not $_.Archived -and ( $_.EnhancedKeyUsageList -match '(1.3.6.1.5.5.7.3.1)' -or -not $_.EnhancedKeyUsageList )
 Get-ChildItem -Recurse cert: `
-  | Where-Object { $_ -is [System.Security.Cryptography.X509Certificates.X509Certificate2] } `
+  | Where-Object { $_ -is [System.Security.Cryptography.X509Certificates.X509Certificate2] -and $_.NotAfter.Date -gt (Get-Date).Date } `
   | ForEach-Object {
-    $name = $_.Subject -replace '[\W]', '_'
+
+    # Write Cert Info (ex. for CSV holding Meta Data); Log Info having full names and additional values for reference
+    Write-Output "$($_.Thumbprint);$($_.GetSerialNumberString());$($_.Archived);$($_.GetExpirationDateString());$($_.EnhancedKeyUsageList);$($_.GetName())"
+
+    # append "Thumbprint" of Cert for unique file names
+    $name = "$($_.Thumbprint)--$($_.Subject)" -replace '[\W]', '_'
+    $max = $name.Length
+
+    # reduce length to prevent filesystem errors
+    if ($max -gt 150) { $max = 150 }
+    $name = $name.Substring(0, $max)
+
+    # build path
+    $path = "{0}\{1}.{2}" -f $StoreToDir,$name,$CertExtension
+    if (Test-Path $path) { continue } # next if cert was already written
+
     $oPem=new-object System.Text.StringBuilder
     [void]$oPem.AppendLine("-----BEGIN CERTIFICATE-----")
     [void]$oPem.AppendLine([System.Convert]::ToBase64String($_.RawData,$InsertLineBreaks))
     [void]$oPem.AppendLine("-----END CERTIFICATE-----")
 
-    $path = "{0}\{1}.pem" -f $StoreToDir,$name
-
-    # the exported list of certificates contains certificates with similar subject
-    # let's put them in separate indexed files
-    $idx = 0
-    While (Test-Path $path) {
-      $idx++
-      $path = "{0}\{1}--{2}.pem" -f $StoreToDir,$name,$idx
-    }
-    If ($idx -gt 0) {
-      $path
-    }
-
-    # TODO unfortunately same certificates duplicates each other
-    # it's better to add a check for duplicates just here
-
     $oPem.toString() | add-content $path
-    #Exit(0)
   }
 
 # The End


### PR DESCRIPTION
Hello,

thanks for your script template, if you like my modification just merge (or manually take over the parts you like, if you only want some of these changes):
- Print CSV style cert data to standard out for all seen certs (not filtered by unique file name). This enables easy check by comparing no. of written lines vs. files
- Filter outdated certs (skip certs having valid until <= today)
- Unique cert files by using Thumbprint of cert
- limit length of file name to handle file system errors (path not found)

Hint: Your "TODO" regarding duplicates was implemented by adding unique thumbprint of cert to file name.

Greets